### PR TITLE
Add a libLLVMPolly -> LLVMPolly symlink.

### DIFF
--- a/llvm_linux.BUILD
+++ b/llvm_linux.BUILD
@@ -11,7 +11,10 @@ filegroup(
 
 filegroup(
     name = "libdir",
-    srcs = ["lib"],
+    srcs = [
+        ":LLVMPolly",
+        "lib",
+    ],
 )
 
 cc_library(

--- a/tools/bzl/macros.bzl
+++ b/tools/bzl/macros.bzl
@@ -1,14 +1,15 @@
 def cc_remap_library(name, src, dst):
-  """Rename a cc_library target.
+    """Rename a cc_library target.
 
     Args:
       name: The name of the target.
       src: The input library.
       dst: The renamed library.
     """
-  native.genrule(
-    name="{}_src".format(name), srcs=[src], outs=[dst], cmd="cp $< $@",
-  )
-  native.cc_library(
-    name=name, srcs=[dst],
-  )
+    native.genrule(
+        name="{}_src".format(name), srcs=[src], outs=[dst],
+        cmd="cp $< $@",
+    )
+    native.cc_library(
+        name=name, srcs=[dst],
+    )


### PR DESCRIPTION
The shared library is named LLVMPolly.so, but some runtimes expect it
to have a lib prefix, causing a load-time error. This creates a
symlink libLLVMPolly.so -> LLVMPolly.so as a workaround.

https://github.com/ChrisCummins/ProGraML/issues/134